### PR TITLE
Removed '**'s so that the license is correctly identified by Github.

### DIFF
--- a/MIT.md
+++ b/MIT.md
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-**Copyright &copy; &lt;year> &lt;copyright holders>**
+Copyright &copy; &lt;year> &lt;copyright holders>
 
 * * *
 


### PR DESCRIPTION
Github uses [Licensee](https://github.com/benbalter/licensee) to automatically detect what license a repo uses, and give it a badge at the top if it detects the language. The '**'s emphasizing the Copyright line seem to throw this off - when these are removed, the license is correctly identified by Github.